### PR TITLE
scales the image if the rotation was changed

### DIFF
--- a/app/src/wasmJsMain/kotlin/Main.kt
+++ b/app/src/wasmJsMain/kotlin/Main.kt
@@ -102,15 +102,19 @@ private fun updateThumbnail(imageBytes: ByteArray?, orientation: TiffOrientation
              */
             imageElement.onload = {
 
+                val naturalWidth = imageElement.width * 1.0
+                val naturalHeight = imageElement.height * 1.0
+
+                val scale = if (naturalWidth > naturalHeight) (naturalHeight / naturalWidth) else 1
+
                 when (orientation) {
-                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT, TiffOrientation.ROTATE_RIGHT,
-                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT, TiffOrientation.ROTATE_LEFT -> {
+                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT,
+                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT -> {
+                        imageElement.style.transform += " scale($scale, -$scale)"
+                    }
 
-                        val naturalWidth = imageElement.width * 1.0
-                        val naturalHeight = imageElement.height * 1.0
-
-                        val scale = if (naturalWidth > naturalHeight) (naturalHeight / naturalWidth) else 1
-
+                    TiffOrientation.ROTATE_RIGHT,
+                    TiffOrientation.ROTATE_LEFT -> {
                         imageElement.style.transform += " scale($scale)"
                     }
 

--- a/app/src/wasmJsMain/kotlin/Main.kt
+++ b/app/src/wasmJsMain/kotlin/Main.kt
@@ -78,25 +78,45 @@ private fun updateThumbnail(imageBytes: ByteArray?, orientation: TiffOrientation
 
             imageElement.src = url
 
-            // FIXME If applied the transformation the image will not fit into the box.
-            //   I was unable to find a solution for this so far.
-//            /*
-//             * Use CSS to rotate the image to keep the original image bytes.
-//             * If the user saves the image to disk it should still be identical to
-//             * the output of "exiftool -b -ThumbnailImage test.jpg > thumb.jpg".
-//             */
-//            val styleTransform = when (orientation) {
-//                TiffOrientation.MIRROR_HORIZONTAL -> "scale(-1, 1)"
-//                TiffOrientation.UPSIDE_DOWN -> "rotate(180deg)"
-//                TiffOrientation.MIRROR_VERTICAL -> "scale(1, -1)"
-//                TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT -> "rotate(-90deg) scale(1, -1)"
-//                TiffOrientation.ROTATE_RIGHT -> "rotate(90deg)"
-//                TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT -> "rotate(90deg) scale(1, -1)"
-//                TiffOrientation.ROTATE_LEFT -> "rotate(-90deg)"
-//                else -> ""
-//            }
-//
-//            imageElement.style.transform = styleTransform
+            /*
+             * Use CSS to rotate the image to keep the original image bytes.
+             * If the user saves the image to disk it should still be identical to
+             * the output of "exiftool -b -ThumbnailImage test.jpg > thumb.jpg".
+             */
+            val styleTransform = when (orientation) {
+                TiffOrientation.MIRROR_HORIZONTAL -> "scale(-1, 1)"
+                TiffOrientation.UPSIDE_DOWN -> "rotate(180deg)"
+                TiffOrientation.MIRROR_VERTICAL -> "scale(1, -1)"
+                TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT -> "rotate(-90deg) scale(1, -1)"
+                TiffOrientation.ROTATE_RIGHT -> "rotate(90deg)"
+                TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT -> "rotate(90deg) scale(1, -1)"
+                TiffOrientation.ROTATE_LEFT -> "rotate(-90deg)"
+                else -> ""
+            }
+
+            imageElement.style.transform = styleTransform
+
+            /*
+             * After the image was loaded, we can use the dimensions to scale
+             * the image down to match the parent container's size
+             */
+            imageElement.onload = {
+
+                when (orientation) {
+                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT, TiffOrientation.ROTATE_RIGHT,
+                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT, TiffOrientation.ROTATE_LEFT -> {
+
+                        val naturalWidth = imageElement.width * 1.0
+                        val naturalHeight = imageElement.height * 1.0
+
+                        val scale = if (naturalWidth > naturalHeight) (naturalHeight / naturalWidth) else 1
+
+                        imageElement.style.transform += " scale($scale)"
+                    }
+
+                    else -> {}
+                }
+            }
 
         } else {
 

--- a/app/src/wasmJsMain/kotlin/Main.kt
+++ b/app/src/wasmJsMain/kotlin/Main.kt
@@ -102,19 +102,15 @@ private fun updateThumbnail(imageBytes: ByteArray?, orientation: TiffOrientation
              */
             imageElement.onload = {
 
-                val naturalWidth = imageElement.width * 1.0
-                val naturalHeight = imageElement.height * 1.0
-
-                val scale = if (naturalWidth > naturalHeight) (naturalHeight / naturalWidth) else 1
-
                 when (orientation) {
-                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT,
-                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT -> {
-                        imageElement.style.transform += " scale($scale, -$scale)"
-                    }
+                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_LEFT, TiffOrientation.ROTATE_RIGHT,
+                    TiffOrientation.MIRROR_HORIZONTAL_AND_ROTATE_RIGHT, TiffOrientation.ROTATE_LEFT -> {
 
-                    TiffOrientation.ROTATE_RIGHT,
-                    TiffOrientation.ROTATE_LEFT -> {
+                        val naturalWidth = imageElement.width * 1.0
+                        val naturalHeight = imageElement.height * 1.0
+
+                        val scale = if (naturalWidth > naturalHeight) (naturalHeight / naturalWidth) else 1
+
                         imageElement.style.transform += " scale($scale)"
                     }
 


### PR DESCRIPTION
a transform does break out from the normal layout. This can be compared to simply rotate the graphics2d in a swing context.
To ensure the image does not exceed its parents dimensions we have to scale the image down